### PR TITLE
feat(app): optimistic comments + events edit/remove/repost + policies…

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -67,7 +67,7 @@ if (!self.define) {
     });
   };
 }
-define(['./workbox-bdf85172'], (function (workbox) { 'use strict';
+define(['./workbox-c5f6b949'], (function (workbox) { 'use strict';
 
   self.skipWaiting();
   workbox.clientsClaim();
@@ -78,13 +78,12 @@ define(['./workbox-bdf85172'], (function (workbox) { 'use strict';
    * See https://goo.gl/S9QRab
    */
   workbox.precacheAndRoute([{
-    "url": "/offline.html",
-    "revision": "0.uijh37o69o8"
+    "url": "/index.html",
+    "revision": "0.lbg66pcp2jg"
   }], {});
   workbox.cleanupOutdatedCaches();
-  workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("/offline.html"), {
-    allowlist: [/^\/$/],
-    denylist: [/^\/api\//, /\/auth\b/]
+  workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("/index.html"), {
+    allowlist: [/^\/$/]
   }));
   workbox.registerRoute(({
     request

--- a/src/api/owner.api.js
+++ b/src/api/owner.api.js
@@ -10,6 +10,23 @@ export async function removeOwner({ ownerId, animalId }) {
   return response.data
 }
 
+
+
+export async function transferPrimaryOwner({ animalId, ownerId }) {
+  const response = await http.patch(`/animals/${animalId}/owner/${ownerId}/primary`)
+  return response.data
+}
+
+// Ocultar pet para mim (delete lógico por usuário)
+export async function hidePetForMe({ animalId }) {
+  const response = await http.post(`/animals/${animalId}/hide`)
+  return response.data
+}
+
+export async function unhidePetForMe({ animalId }) {
+  const response = await http.post(`/animals/${animalId}/unhide`)
+  return response.data
+}
 export async function fetchAnimalsByOwner({ userId, query, page = 1, perPage = 10 }) {
   const response = await http.get(`/animals/owners/${userId}`, {
     params: {

--- a/src/features/feed/pages/Feed.jsx
+++ b/src/features/feed/pages/Feed.jsx
@@ -955,37 +955,40 @@ export default function Feed() {
       try {
         // 2) confirma no backend e substitui o temporário
         const created = await addCommentPost({ postId, message });
-        let newC = normComment(created);
-        if (!newC.author?.id && me) {
-          newC = {
-            ...newC,
-            author: {
-              id: me.id,
-              username: me.username,
-              name: me.name,
-              email: (me.email || "").toLowerCase(),
-              avatar: me.image || me.avatar || "",
-            },
-          };
-        }
 
-        setPosts((curr) =>
-          curr.map((p) => {
-            if (String(p.id) !== String(postId)) return p;
-            const next = (p.comments || []).map((c) => (c.id === tempId ? newC : c));
-            return { ...p, comments: next };
-          })
-        );
+        // O backend pode retornar body vazio (201 sem JSON). Nesse caso, mantemos o otimista.
+        const hasPayload =
+          created &&
+          typeof created === "object" &&
+          (created.id || created._id || created.text || created.message);
+
+        if (hasPayload) {
+          let newC = normComment(created);
+          if (!newC.author?.id && me) {
+            newC = {
+              ...newC,
+              author: {
+                id: me.id,
+                username: me.username,
+                name: me.name,
+                email: (me.email || "").toLowerCase(),
+                avatar: me.image || me.avatar || "",
+              },
+            };
+          }
+
+          setPosts((curr) =>
+            curr.map((p) => {
+              if (String(p.id) !== String(postId)) return p;
+              const next = (p.comments || []).map((c) => (c.id === tempId ? newC : c));
+              return { ...p, comments: next };
+            })
+          );
+        }
       } catch (e) {
         console.error(e);
-        // remove o otimista se falhar
-        setPosts((curr) =>
-          curr.map((p) => {
-            if (String(p.id) !== String(postId)) return p;
-            return { ...p, comments: (p.comments || []).filter((c) => c.id !== tempId) };
-          })
-        );
-        window.alert("Não foi possível enviar o comentário. Tente novamente.");
+        // mantém o comentário otimista visível e avisa que não sincronizou
+        window.alert("Comentário criado localmente, mas não foi possível sincronizar agora. Tente novamente mais tarde.");
       }
     },
     [me]
@@ -1036,47 +1039,45 @@ export default function Feed() {
 
       try {
         const created = await addCommentPost({ postId, message, parentId: parentCommentId });
-        let reply = normComment(created);
-        if (!reply.author?.id && me) {
-          reply = {
-            ...reply,
-            author: {
-              id: me.id,
-              username: me.username,
-              name: me.name,
-              email: (me.email || "").toLowerCase(),
-              avatar: me.image || me.avatar || "",
-            },
-          };
-        }
 
-        // 2) substitui o temporário
-        setPosts((curr) =>
-          curr.map((p) => {
-            if (String(p.id) !== String(postId)) return p;
-            const comments = (p.comments || []).map((c) => {
-              if (c.id !== parentCommentId) return c;
-              const replies = (c.replies || []).map((r) => (r.id === tempId ? reply : r));
-              return { ...c, replies };
-            });
-            return { ...p, comments };
-          })
-        );
+        // O backend pode retornar body vazio (201 sem JSON). Nesse caso, mantemos o otimista.
+        const hasPayload =
+          created &&
+          typeof created === "object" &&
+          (created.id || created._id || created.text || created.message);
+
+        if (hasPayload) {
+          let reply = normComment(created);
+          if (!reply.author?.id && me) {
+            reply = {
+              ...reply,
+              author: {
+                id: me.id,
+                username: me.username,
+                name: me.name,
+                email: (me.email || "").toLowerCase(),
+                avatar: me.image || me.avatar || "",
+              },
+            };
+          }
+
+          // 2) substitui o temporário
+          setPosts((curr) =>
+            curr.map((p) => {
+              if (String(p.id) !== String(postId)) return p;
+              const comments = (p.comments || []).map((c) => {
+                if (c.id !== parentCommentId) return c;
+                const replies = (c.replies || []).map((r) => (r.id === tempId ? reply : r));
+                return { ...c, replies };
+              });
+              return { ...p, comments };
+            })
+          );
+        }
       } catch (e) {
         console.error(e);
-        // remove otimista
-        setPosts((curr) =>
-          curr.map((p) => {
-            if (String(p.id) !== String(postId)) return p;
-            const comments = (p.comments || []).map((c) => {
-              if (c.id !== parentCommentId) return c;
-              const replies = (c.replies || []).filter((r) => r.id !== tempId);
-              return { ...c, replies };
-            });
-            return { ...p, comments };
-          })
-        );
-        window.alert("Não foi possível enviar a resposta. Tente novamente.");
+        // mantém a resposta otimista visível e avisa que não sincronizou
+        window.alert("Resposta criada localmente, mas não foi possível sincronizar agora. Tente novamente mais tarde.");
       }
     },
     [me]

--- a/src/features/pets/pages/PetDetail.jsx
+++ b/src/features/pets/pages/PetDetail.jsx
@@ -33,7 +33,7 @@ import heic2any from "heic2any";
 // APIs
 import { getMyProfile, fetchUsersProfile, getUserProfile } from "@/api/user.api.js";
 import { fetchAnimalsById } from "@/api/animal.api.js";
-import { addOwner, removeOwner } from "@/api/owner.api.js";
+import { addOwner, removeOwner, transferPrimaryOwner, hidePetForMe } from "@/api/owner.api.js";
 import {
   fetchAnimalMedias,
   uploadAnimalMedias,
@@ -522,6 +522,7 @@ export default function PetDetail() {
           image: a?.image?.url || a.image || a?.breed?.image || "",
           imageCover: a?.imageCover?.url || a.imageCover || "",
           ownerId: primaryOwnerId,
+          createdByOwnerId: a?.createdByOwnerId || a?.created_by_owner_id || null,
           ownerIds: ownersFromArray.length ? ownersFromArray : primaryOwnerId ? [primaryOwnerId] : [],
         });
 
@@ -551,10 +552,14 @@ export default function PetDetail() {
   const canEdit = useMemo(() => {
     const myId = me?.id ? String(me.id) : null;
     const primary = pet?.ownerId ? String(pet.ownerId) : null;
-    const many = Array.isArray(pet?.ownerIds) ? pet.ownerIds.map(String) : [];
-    if (!myId) return false;
-    return myId === primary || many.includes(myId);
-  }, [me?.id, pet?.ownerId, pet?.ownerIds]);
+    if (!myId || !primary) return false;
+    return myId === primary;
+  }, [me?.id, pet?.ownerId]);
+
+  const myIdStr = me?.id ? String(me.id) : null;
+  const primaryOwnerIdStr = pet?.ownerId ? String(pet.ownerId) : null;
+  const isPrimaryTutor = !!myIdStr && !!primaryOwnerIdStr && myIdStr === primaryOwnerIdStr;
+  const isOriginalCreator = !!myIdStr && String(pet?.createdByOwnerId || '') === myIdStr;
 
 
 
@@ -671,6 +676,13 @@ export default function PetDetail() {
     const id = ownerId ? String(ownerId) : null;
     if (!id) return;
 
+    // não permite remover tutor principal
+    const primary = pet?.ownerId ? String(pet.ownerId) : null;
+    if (primary && id === primary) {
+      toast.error('Não é possível remover o tutor principal.');
+      return;
+    }
+
     // não deixa remover o último tutor
     const current = Array.isArray(pet?.ownerIds) ? pet.ownerIds.map(String) : [];
     if (current.length <= 1) {
@@ -699,6 +711,52 @@ export default function PetDetail() {
       toast.error("Falha ao remover tutor.");
     }
   };
+
+  const makePrimaryTutor = async (ownerId) => {
+    const id = ownerId ? String(ownerId) : null;
+    if (!id) return;
+    if (!isPrimaryTutor) {
+      toast.error('Apenas o tutor principal pode transferir a tutoria.');
+      return;
+    }
+    if (String(pet?.ownerId || '') === id) return;
+
+    const ok = await confirm({
+      title: 'Tornar tutor principal?',
+      description: 'Você transferirá a tutoria principal. Depois disso, você não poderá remover o novo tutor principal.',
+      confirmText: 'Transferir',
+      tone: 'danger',
+    });
+    if (!ok) return;
+
+    try {
+      await transferPrimaryOwner({ animalId, ownerId: id });
+      toast.success('Tutoria principal transferida.');
+      setPet((p) => ({ ...p, ownerId: id }));
+    } catch (e) {
+      console.error(e);
+      toast.error('Falha ao transferir tutoria.');
+    }
+  };
+
+  const hideThisPetForMe = async () => {
+    const ok = await confirm({
+      title: 'Remover pet da minha lista?',
+      description: 'Isso é um delete lógico: o pet não some do sistema, apenas deixa de aparecer para você.',
+      confirmText: 'Remover da minha lista',
+      tone: 'danger',
+    });
+    if (!ok) return;
+    try {
+      await hidePetForMe({ animalId });
+      toast.success('Pet removido da sua lista.');
+      navigate('/pets');
+    } catch (e) {
+      console.error(e);
+      toast.error('Não foi possível remover da sua lista.');
+    }
+  };
+
   /* -------------------------- galeria: listar/upload/delete ---------------- */
   const refetchGallery = useRef(null);
 
@@ -1524,19 +1582,43 @@ export default function PetDetail() {
                       </div>
                     </Link>
 
-                    {canEdit && owners.length > 1 && (
-                      <button
+                    {canEdit && owners.length > 1 && String(o.id) !== String(pet?.ownerId) && String(o.id) !== String(me?.id) && (
+                      <div className="flex items-center gap-2">
+                        <button
                         type="button"
                         onClick={() => removeTutorFromPet(o.id)}
                         className="inline-flex items-center gap-1 rounded-lg border border-zinc-300 bg-white px-2 py-1 text-xs hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
                         title="Remover tutor"
                       >
                         <UserMinus className="h-3.5 w-3.5" /> Remover
-                      </button>
+                        </button>
+
+                        <button
+                          type="button"
+                          onClick={() => makePrimaryTutor(o.id)}
+                          className="inline-flex items-center gap-1 rounded-lg border border-zinc-300 bg-white px-2 py-1 text-xs hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+                          title="Tornar tutor principal"
+                        >
+                          Principal
+                        </button>
+                      </div>
                     )}
                   </li>
                 ))}
-              </ul>
+              
+
+            {isOriginalCreator && !isPrimaryTutor && (pet?.ownerIds || []).length > 1 && (
+              <div className="mt-3">
+                <button
+                  type="button"
+                  onClick={() => removeTutorFromPet(me?.id)}
+                  className="inline-flex items-center gap-2 rounded-xl border border-zinc-300 bg-white px-3 py-2 text-xs font-semibold hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+                >
+                  Sair da tutoria
+                </button>
+              </div>
+            )}
+</ul>
             )}
           </div>
         </section>


### PR DESCRIPTION
O que foi feito
1) Comentários (UX)

Comentários/respostas com atualização otimista (aparecem imediatamente).
Tratamento para backend que retornava body vazio (agora mantém o otimista até sincronizar).
Edição de comentário/resposta com update otimista + fallback.
2) Eventos

Ações do evento somente dentro da página do evento e somente para o autor:
editar evento
remover evento
repostar no feed
Correção do “dono do evento” usando authorId.
3) Tutoria (regras de negócio)

UI ajustada para “tutor principal”:
só tutor principal vê “Adicionar tutor”
não mostrar botão de remover para tutor principal nem para si mesmo
botão “Principal” para transferir tutoria
tutor não-principal: “Remover da minha lista” (hide lógico)
criador original: “Sair da tutoria” após transferir
4) Políticas/Ajuda

Páginas de políticas com layout/rota padronizados (sidebar quando logado).
Textos enriquecidos (privacidade, diretrizes, canal de denúncia).
5) PWA Dev

Dependência workbox-window para evitar erro do vite-plugin-pwa no dev.
Dependências de backend
Requer backend com:
retorno de DTO em comentários
endpoints de medicações
endpoints de tutoria (transfer primary/hide)
endpoint de repost do evento
Como testar
Feed: comentar/responder/editar e confirmar que aparece na hora.
Evento: abrir evento do autor e ver botões; abrir evento de outro e não ver.
Pet: tutor principal gerencia tutores; tutor secundário não remove tutor principal e consegue ocultar o pet.
Políticas: acessar páginas e confirmar layout consistente.